### PR TITLE
JohnCS - Slow while loop down by 1ms

### DIFF
--- a/BhopcsgoSig/John.cpp
+++ b/BhopcsgoSig/John.cpp
@@ -104,8 +104,7 @@ int main()
 		}
 
 	}
-
-
+	Sleep(1); // Sleep for 1ms, saves CPU time.
 }
 
 class xdbiqga {


### PR DESCRIPTION
Slowing down the loop by 1ms will stop GetAsyncKeyState from consuming  
ridiculous amounts of the CPU and thus helping performance of the hack.