### PR TITLE
JohnCS - Constantly update client.dll base

### DIFF
--- a/BhopcsgoSig/John.cpp
+++ b/BhopcsgoSig/John.cpp
@@ -76,7 +76,6 @@ int main()
 	}
 	printf("[*] pid: %d\n", pid);
 	HANDLE hProcess = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
-	uintptr_t clint = GetModuleBaseAddress(pid, L"client.dll");
 	uintptr_t dwLocalPlayer;
 
 	int m_fFlags;
@@ -84,6 +83,7 @@ int main()
 	int godown = 4; 
 	while (true)
 	{
+		uintptr_t clint = GetModuleBaseAddress(pid, L"client.dll");
 		ReadProcessMemory(hProcess, (LPCVOID)(clint + hazedumper::signatures::dwLocalPlayer), &dwLocalPlayer, sizeof(uintptr_t), NULL);
 		
 		while (GetAsyncKeyState(VK_SPACE) & 0x8000)


### PR DESCRIPTION
This program will get a handle to CSGO upon opening so fast that the client.dll  
base address is completely wrong and thus we need to ensure it's always updated.  
This is a slight hack but won't affect performance too much.